### PR TITLE
Spelling fixes for Starcross

### DIFF
--- a/actions.zil
+++ b/actions.zil
@@ -4146,7 +4146,7 @@ as the artifact positions itself to follow the course you have set." CR>
 		       <SETG WON-FLAG T>
 		       <TELL
 "The artifact, under your assured control, moves serenely toward Earth, where
-the knowledge it contains will immeasureably benefit mankind. Within a few
+the knowledge it contains will immeasurably benefit mankind. Within a few
 years, there could be human ships flying out to the stars, and all because of
 your daring and cunning...|
 |

--- a/actions.zil
+++ b/actions.zil
@@ -1926,7 +1926,7 @@ with an airlock. The surface looks metallic." CR>)
 	 <COND (<NOT ,DOCKED?> <TELL "What artifact?" CR>)
 	       (<VERB? EXAMINE FIND>
 		<COND (,IN-ARTIFACT? <TELL "It's all around!" CR>)
-		      (ELSE <TELL "It's right here.!" CR>)>)>>
+		      (ELSE <TELL "It's right here!" CR>)>)>>
 
 <GLOBAL SUIT-ON? <>>
 


### PR DESCRIPTION
These are the spelling fixes for Starcross from The ZIL Files. The usual caveats apply: I'm not a native English speaker, so please check that the fixes are correct.